### PR TITLE
Update Docker Compose config to populate cities data on load

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -13,3 +13,5 @@ services:
       POSTGRES_PASSWORD: mypassword
     ports:
         - "5432:5432"
+    volumes:
+      - ./psql-cities-data/world.sql:/docker-entrypoint-initdb.d/world.sql


### PR DESCRIPTION
- Update `compose.yml` to load `world.sql` into the PostgreSQL on `docker compose up`
- Correct errors in `world.sql` that were preventing Docker from being able to load the data