### PR TITLE
feat: add functionality to clear cache and data visualizations

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import SummaryGauges from './components/SummaryGauges';
 import CustomSelectQuery from './components/CustomSelectQuery';
 import CustomInsertQuery from './components/CustomInsertQuery';
 import FrequencyDistribution from './components/FrequencyDistribution';
+import ClearCacheButton from './components/ClearCacheButton';
 
 const App: React.FC = () => {
   const [cacheSwitch, setCacheSwitch] = useState<boolean>(true);
@@ -40,22 +41,32 @@ const App: React.FC = () => {
         <Routes>
           <Route path="/" element={
             <Box display='flex' flexDirection='column' alignItems='center' padding={3} minHeight='30vh'>
-              <CacheSwitch cacheSwitch={cacheSwitch} setCacheSwitch={setCacheSwitch} />
+              <Box display='flex' alignItems='center'>
+                <CacheSwitch cacheSwitch={cacheSwitch} setCacheSwitch={setCacheSwitch} />
+                <ClearCacheButton
+                  setCacheHits={setCacheHits}
+                  setCacheMisses={setCacheMisses}
+                  setResponseTimes={setResponseTimes}
+                  setQueryResult={setQueryResult}
+                />
+              </Box>
               <Box padding={2} width='50%'>
                 <QueryBox querySelect={querySelect} setQuerySelect={setQuerySelect} />
               </Box>
-              <SubmitButton
-                cacheSwitch={cacheSwitch}
-                querySelect={querySelect}
-                cacheHits={cacheHits}
-                setCacheHits={setCacheHits}
-                cacheMisses={cacheMisses}
-                setCacheMisses={setCacheMisses}
-                responseTimes={responseTimes}
-                setResponseTimes={setResponseTimes}
-                queryResult={queryResult}
-                setQueryResult={setQueryResult}
-              />
+              <Box padding={2} width='50%' display='flex' justifyContent='center'>
+                <SubmitButton
+                  cacheSwitch={cacheSwitch}
+                  querySelect={querySelect}
+                  cacheHits={cacheHits}
+                  setCacheHits={setCacheHits}
+                  cacheMisses={cacheMisses}
+                  setCacheMisses={setCacheMisses}
+                  responseTimes={responseTimes}
+                  setResponseTimes={setResponseTimes}
+                  queryResult={queryResult}
+                  setQueryResult={setQueryResult}
+                />
+              </Box>
               <ResponseTimeChart responseTimes={responseTimes} />
               <CacheMetricsChart cacheHits={cacheHits} cacheMisses={cacheMisses} />
               <QueryResultBox queryResult={queryResult} />
@@ -72,3 +83,4 @@ const App: React.FC = () => {
 };
 
 export default App;
+

--- a/client/src/components/ClearCacheButton.tsx
+++ b/client/src/components/ClearCacheButton.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Button } from '@mui/material';
+
+interface ClearCacheButtonProps {
+  setCacheHits: React.Dispatch<React.SetStateAction<number>>;
+  setCacheMisses: React.Dispatch<React.SetStateAction<number>>;
+  setResponseTimes: React.Dispatch<React.SetStateAction<number[]>>;
+  setQueryResult: React.Dispatch<React.SetStateAction<any>>;
+  label?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+}
+
+const ClearCacheButton: React.FC<ClearCacheButtonProps> = ({
+  setCacheHits,
+  setCacheMisses,
+  setResponseTimes,
+  setQueryResult,
+  label = 'Clear Cache',
+  onClick,
+  disabled = false,
+}) => {
+  const handleClick = async () => {
+    try {
+      await fetch('/deleteCache', {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      setCacheHits(0);
+      setCacheMisses(0);
+      setResponseTimes([]);
+      setQueryResult({});
+
+      if (onClick) {
+        onClick();
+      }
+    } catch (error) {
+      console.error('Error clearing cache:', error);
+    }
+  };
+
+  return (
+    <Button variant='contained' color='secondary' onClick={handleClick} disabled={disabled}>
+      {label}
+    </Button>
+  );
+};
+
+export default ClearCacheButton;

--- a/client/src/components/FrequencyDistribution.tsx
+++ b/client/src/components/FrequencyDistribution.tsx
@@ -20,7 +20,7 @@ const FrequencyDistribution = () => {
 
   const fetchData = async () => {
     try {
-      const response = await fetch('ttps://4920a04e-c579-4e3e-8106-1c179e75ac0e.mock.pstmn.io/distribution');
+      const response = await fetch('https://4920a04e-c579-4e3e-8106-1c179e75ac0e.mock.pstmn.io/distribution');
       if (!response.ok) {
         throw new Error("Network response was not ok");
       }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -55,7 +55,7 @@ export default {
     },
     proxy: [
       {
-        context: ['/data', '/test', '/cache-analytics', '/cache-response-times'],
+        context: ['/data', '/test', '/cache-analytics', '/cache-response-times', '/deleteCache'],
         target: 'http://localhost:3030',
       },
     ],


### PR DESCRIPTION
<!---
☝️ Prefix your PR title with `fix:`, `feat:`, `docs:`, or other according to the Conventional Commits spec:
https://conventionalcommits.org

👉 Please make sure to follow the Contributing guidelines:
https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md
-->

## Linked issue/ticket

<!-- GitHub Issue / Jira Ticket / Asana Ticket -->
https://jayanrpillai.atlassian.net/browse/CAM-27

## Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This change provides a button that allows the user to clear the Redis cache on the backend and clear the data that powers the visualizations, allowing them to reset the experience without the server needing to be restarted. 

## Reproduction steps

<!-- Include step-by-step instructions on how to reproduce and test this ticket. -->

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [ ] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)
